### PR TITLE
Add job queuing capability to Genie for protection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'nebula.provided-base' version '2.2.2'
 }
 
-version = "2.3.0"
+version = "2.3.1"
 
 ext.githubProjectName = rootProject.name
 

--- a/genie-common/src/main/java/com/netflix/genie/common/model/JobStatus.java
+++ b/genie-common/src/main/java/com/netflix/genie/common/model/JobStatus.java
@@ -32,6 +32,10 @@ public enum JobStatus {
      */
     INIT,
     /**
+     * Job has been flagged in the DB to wait instead of running.
+     */
+    QUEUED,
+    /**
      * Job is now running.
      */
     RUNNING,
@@ -52,7 +56,7 @@ public enum JobStatus {
      * Parse job status.
      *
      * @param value string to parse/convert
-     * @return INIT, RUNNING, SUCCEEDED, KILLED, FAILED if match
+     * @return INIT, RUNNING, QUEUED, SUCCEEDED, KILLED, FAILED if match
      * @throws GeniePreconditionException if invalid value passed in
      */
     public static JobStatus parse(final String value) throws GeniePreconditionException {

--- a/genie-common/src/test/java/com/netflix/genie/common/model/TestJobStatus.java
+++ b/genie-common/src/test/java/com/netflix/genie/common/model/TestJobStatus.java
@@ -36,6 +36,7 @@ public class TestJobStatus {
     @Test
     public void testValidJobStatus() throws GeniePreconditionException {
         Assert.assertEquals(JobStatus.RUNNING, JobStatus.parse(JobStatus.RUNNING.name().toLowerCase()));
+        Assert.assertEquals(JobStatus.QUEUED, JobStatus.parse(JobStatus.QUEUED.name().toLowerCase()));
         Assert.assertEquals(JobStatus.FAILED, JobStatus.parse(JobStatus.FAILED.name().toLowerCase()));
         Assert.assertEquals(JobStatus.KILLED, JobStatus.parse(JobStatus.KILLED.name().toLowerCase()));
         Assert.assertEquals(JobStatus.INIT, JobStatus.parse(JobStatus.INIT.name().toLowerCase()));

--- a/genie-server/src/main/java/com/netflix/genie/server/metrics/JobCountManager.java
+++ b/genie-server/src/main/java/com/netflix/genie/server/metrics/JobCountManager.java
@@ -66,6 +66,14 @@ public interface JobCountManager {
             final Long maxStartTime) throws GenieException;
 
     /**
+     * Get number of running jobs system wide.
+     *
+     * @return number of total running jobs in the system
+     * @throws GenieException if there is an error
+     */
+    int getNumRunningJobs() throws GenieException;
+
+    /**
      * Returns the most idle Genie instance (&lt; minJobThreshold running jobs),
      * if possible - else returns current instance.
      *

--- a/genie-server/src/main/java/com/netflix/genie/server/services/JobService.java
+++ b/genie-server/src/main/java/com/netflix/genie/server/services/JobService.java
@@ -50,6 +50,38 @@ public interface JobService {
             final Job job
     ) throws GenieException;
 
+
+    /**
+     * Validate the job and persist it with QUEUED status if it passes validation.
+     *
+     * This method is the alternative to createJob/runJob when we want to queue it.
+     *
+     * @param job The job to validate and maybe save
+     * @return The validated/saved job object
+     * @throws GenieException if there is an error
+     */
+    Job queueJob(
+            @NotNull(message = "No job entered. Unable to queue.")
+            @Valid
+            final Job job
+    ) throws GenieException;
+
+
+    /**
+     * Unqueue the job and prepare to run it, getting in into the same state as craeteJob so
+     * that runJob can be called.
+     *
+     * @param id The id of the job to unqueue and start to run
+     * @return The unqueued/validated/saved job object
+     * @throws GenieException if there is an error
+     */
+    Job unQueueJob(
+            @NotNull(message = "No job entered. Unable to unqueue.")
+            @Valid
+            final String id
+    ) throws GenieException;
+
+
     /**
      * Get job information for given job id.
      *
@@ -61,6 +93,18 @@ public interface JobService {
             @NotBlank(message = "No id entered. Unable to get job.")
             final String id
     ) throws GenieException;
+
+    /**
+     * Convenience method to get the oldest queued job in the system or null if
+     * none exist.
+     *
+     * Uses the getJobs call to get queued jobs ordered by creation time
+     * ascending.
+     *
+     * @return The oldest queued job or null if no queued jobs in the system
+     */
+    Job getOldestQueuedJob();
+
 
     /**
      * Get job info for given filter criteria.

--- a/genie-server/src/test/java/com/netflix/genie/server/metrics/impl/TestJobCountManagerImpl.java
+++ b/genie-server/src/test/java/com/netflix/genie/server/metrics/impl/TestJobCountManagerImpl.java
@@ -109,4 +109,16 @@ public class TestJobCountManagerImpl {
         );
         Assert.assertEquals(0, this.manager.getNumInstanceJobs(0L, 0L));
     }
+
+    /**
+     * Test getting total number of running jobs system wide.
+     *
+     * @throws GenieException For any problem if there is any error during this test
+     */
+    @Test
+    @DatabaseSetup("testNumInstanceJobs2.xml")
+    public void testGetNumRunningJobs() throws GenieException {
+        Assert.assertEquals(3, this.manager.getNumRunningJobs());
+    }
+
 }

--- a/genie-server/src/test/resources/com/netflix/genie/server/metrics/impl/testNumInstanceJobs2.xml
+++ b/genie-server/src/test/resources/com/netflix/genie/server/metrics/impl/testNumInstanceJobs2.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2015 Netflix, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<dataset>
+    <Job id="job1" 
+         created="2016-06-01 16:02:00"
+         updated="2016-06-01 16:02:00"
+		 processHandle="-1"
+         user="tgianos" 
+         commandId="15" 
+         commandName="pig" 
+         status="INIT" 
+         name="one" 
+         commandArgs="-tez"
+		 started="2014-07-01 16:27:38"
+         clusterCriteriasString="y,x|h2query,adhoc" 
+    	 commandCriteriaString="tag2,tag1"
+		 hostName="worker1"
+         version="1"/>
+    
+    <Job id="job2" 
+         created="2016-06-01 16:03:00"
+         updated="2016-06-01 16:03:00"
+		 processHandle="256"
+         user="dbennett"
+         commandId="15" 
+         commandName="pig" 
+         status="RUNNING" 
+         name="two" 
+         commandArgs="-tez"
+         clusterCriteriasString="y,x|h2query,adhoc" 
+    	 commandCriteriaString="tag2,tag1"
+		 hostName="worker2"
+         started="2014-07-01 16:27:39"
+    	 version="2"/>
+    
+    <Job id="job3" 
+         created="2016-06-01 16:04:00"
+         updated="2016-06-01 16:04:00"
+		 processHandle="310"
+         user="syin"
+         commandId="15" 
+         commandName="pig" 
+         status="RUNNING"
+         clusterCriteriasString="y,x|h2query,adhoc" 
+    	 commandCriteriaString="tag2,tag1"
+         name="three" 
+         commandArgs="-tez"
+		 hostName="worker5"
+		 started="2014-07-01 16:27:40"
+         version="3"/>
+    
+    <Job id="job4" 
+         created="2016-06-01 16:05:00"
+         updated="2016-06-01 16:05:00"
+		 processHandle="-1"
+         user="xli"
+         commandId="15" 
+         commandName="pig" 
+         status="QUEUED"
+         name="four" 
+         clusterCriteriasString="y,x|h2query,adhoc" 
+    	 commandCriteriaString="tag2,tag1"    
+         commandArgs="-tez"
+         started="2014-07-01 16:27:41"
+         version="4"/>
+    
+    <Job id="job5" 
+         created="2016-06-01 16:06:00"
+         updated="2016-06-01 16:06:00"
+		 processHandle="191"
+         user="awadia"
+         commandId="15" 
+         commandName="pig" 
+         status="FAILED" 
+         name="five" 
+         commandArgs="-tez"
+         clusterCriteriasString="y,x|h2query,adhoc" 
+    	 commandCriteriaString="tag2,tag1"
+		 hostName="worker2"
+         started="2014-07-01 16:27:42"
+         version="5"/>
+</dataset>

--- a/genie-server/src/test/resources/com/netflix/genie/server/services/impl/jpa/job/init.xml
+++ b/genie-server/src/test/resources/com/netflix/genie/server/services/impl/jpa/job/init.xml
@@ -239,4 +239,39 @@
     <Job_tags
             JOB_ID="job2"
             element="tag2"/>
+
+    <Job
+            id="job31"
+            created="2016-08-08 16:46:00"
+            updated="2016-08-09 03:12:00"
+            user="dpb"
+            name="y-spark-submit"
+            version="2.7"
+            commandArgs="-f -j"
+            status="QUEUED"
+            commandCriteriaString="spark-submit"
+            clusterCriteriasString="prod,spark161"
+            executionClusterId="prod-spark161"
+            executionClusterName="prod-spark161"
+            commandId="spark-submit-162"
+            commandName="spark-submit-162"
+            processHandle="-1"/>
+
+    <Job
+            id="job32"
+            created="2016-08-09 16:46:00"
+            updated="2016-08-10 03:12:00"
+            user="dpb"
+            name="z-spark-submit"
+            version="2.7"
+            commandArgs="-f -j"
+            status="QUEUED"
+            commandCriteriaString="spark-submit"
+            clusterCriteriasString="prod,spark161"
+            executionClusterId="prod-spark161"
+            executionClusterName="prod-spark161"
+            commandId="spark-submit-162"
+            commandName="spark-submit-162"
+            processHandle="-1"/>
+
 </dataset>

--- a/genie-web/src/main/resources/genie.properties
+++ b/genie-web/src/main/resources/genie.properties
@@ -166,6 +166,9 @@ com.netflix.genie.server.metrics.sleep.ms=30000
 # Job throttling/forwarding Settings
 ###########################################################################
 
+# max running jobs in total in the system after which they are queued
+com.netflix.genie.server.max.system.jobs=40
+
 # max running jobs on this instance, after which 503s are thrown
 com.netflix.genie.server.max.running.jobs=30
 


### PR DESCRIPTION
Add a new job status QUEUED and implement methods to allow jobs
to be stored in the database with a QUEUED status.  Using a
new parameter for max system jobs, we can limit the total number
of running jobs and tailor it to our clusters.

New prop: com.netflix.genie.server.max.system.jobs
