### PR TITLE
Clean up hadoop logic and bump WAR version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'nebula.provided-base' version '2.2.2'
 }
 
-version = "2.3.1"
+version = "2.3.2"
 
 ext.githubProjectName = rootProject.name
 

--- a/genie-server/src/main/java/com/netflix/genie/server/jobmanager/impl/YarnJobManagerImpl.java
+++ b/genie-server/src/main/java/com/netflix/genie/server/jobmanager/impl/YarnJobManagerImpl.java
@@ -142,10 +142,12 @@ public class YarnJobManagerImpl extends JobManagerImpl {
                         JobManagerImpl.SEMI_COLON)
         );
 
-        // if the cluster version is provided, overwrite the HADOOP_HOME
-        // environment variable
+        // Note: unfortunately they use the cluster version as the "hadoop version".  If it's
+        // null or set to 0.0.0 just use the default home which is usually a symlink to the
+        // current version.  Keep this ability in case we DO have a need to run multiple versions
+        // (not likely yet).
         String hadoopHome;
-        if (this.getCluster().getVersion() != null) {
+        if (this.getCluster().getVersion() != null && !this.getCluster().getVersion().equals("0.0.0")) {
             String hadoopVersion = this.getCluster().getVersion();
             LOG.debug("Hadoop Version of the cluster: " + hadoopVersion);
 

--- a/genie-server/src/main/java/com/netflix/genie/server/services/impl/jpa/ExecutionServiceJPAImpl.java
+++ b/genie-server/src/main/java/com/netflix/genie/server/services/impl/jpa/ExecutionServiceJPAImpl.java
@@ -267,10 +267,6 @@ public class ExecutionServiceJPAImpl implements ExecutionService {
         }
         job.setExitCode(exitCode);
 
-        // TODO: if we have queued jobs, submit the oldest one from the list before returning.
-        // Be careful of possible race conditions, we could do that be keeping the original instance
-        // that was assigned but that also has it's drawbacks.
-
         // We check if status code is killed. The kill thread sets this, but just to make sure we set
         // it here again to prevent a race condition problem. This just makes the status message as
         // killed and prevents some jobs that are killed being marked as failed

--- a/genie-web/src/main/resources/genie.properties
+++ b/genie-web/src/main/resources/genie.properties
@@ -166,7 +166,7 @@ com.netflix.genie.server.metrics.sleep.ms=30000
 # Job throttling/forwarding Settings
 ###########################################################################
 
-# max running jobs in total in the system after which they are queued
+# NEW: max running jobs in total in the system after which they are queued
 com.netflix.genie.server.max.system.jobs=40
 
 # max running jobs on this instance, after which 503s are thrown


### PR DESCRIPTION
Made it so that version 0.0.0 means to use the version of hadoop installed at
the symlink that we think is the current version.  Allows us to get around having
to set this to null in the DB.